### PR TITLE
Resolve netlify build issue

### DIFF
--- a/src/components/navbarlinks/NavbarLinks.tsx
+++ b/src/components/navbarlinks/NavbarLinks.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Link from '../link/Link';
+import NavbarLinksStyled from './NavbarLinks.styled';
+import CV from '../../assets/JacekSupernakCV.pdf';
+
+const NavbarLinks:React.FC = () => (
+  <NavbarLinksStyled>
+    <Link text="experience" href="#experience" />
+    <Link text="projects" href="#projects" />
+    <Link text="get in touch" href="#contact" />
+    <Link text="cv" href={CV} />
+  </NavbarLinksStyled>
+);
+
+export default NavbarLinks;


### PR DESCRIPTION
Apparently even though on my local machine I have changed the name of one of the component, the name haven't been being updated on the github even though the source of the file had been updated many time. Having still the old naming of the "Navbarlinks" instead of "NavbarLinks" on the repo provided a crash in a build. Had to manually remove and recreate a file with a correct casing.