### PR TITLE
Fix the performance issue for the mobile caused by blurred eclipses

### DIFF
--- a/src/components/eclipses/Eclipses.styled.tsx
+++ b/src/components/eclipses/Eclipses.styled.tsx
@@ -8,6 +8,21 @@ interface EclipseProps {
   opacity?: number;
 }
 
+export const EclipsesContainerStyled = styled.div`
+  display: none;
+
+  @supports (-moz-appearance:none) {
+    & :nth-child(2) {
+      background-color: ${({ theme }) => theme.secondaryLight};
+      left: 75%;
+    }
+  }
+
+  @media (min-width: ${({ theme }) => theme.screen.tablet}) {
+        display: block;
+    }
+`;
+
 export const EclipseStyled = styled.div<EclipseProps>`
   position: absolute;
   background-color: ${({ theme }) => theme.secondaryLight};
@@ -19,13 +34,4 @@ export const EclipseStyled = styled.div<EclipseProps>`
   filter: blur(${(props) => props.blur});
   opacity:  ${(props) => (props.opacity ? props.opacity : 1)};
   z-index: -1;
-`;
-
-export const EclipsesContainerStyled = styled.div`
-  @supports (-moz-appearance:none) {
-    & :nth-child(2) {
-      background-color: ${({ theme }) => theme.secondaryLight};
-      left: 75%;
-    }
-  }
 `;

--- a/src/theme/global.ts
+++ b/src/theme/global.ts
@@ -13,7 +13,10 @@ const GlobalStyle = createGlobalStyle`
         scroll-behavior: smooth;
     }
     body {
-        background-color: ${({ theme }) => theme.primaryDark};
+        background: ${({ theme }) => `linear-gradient(80deg, ${theme.primaryDark} 40%, ${theme.secondaryLight} 350%)`};
+        @media (min-width: ${({ theme }) => theme.screen.tablet}) {
+            background: ${({ theme }) => theme.primaryDark};
+        }
         overflow-x: hidden;
     }
     #root {


### PR DESCRIPTION
### Problem:
-  Blurred 'in-real-time-generated' eclipses causing great performance drop on the mobile devices

### Solution:
- Remove the eclipses from the mobile view.
- Replace the eclipses with the regular background gradient that uses same colors.